### PR TITLE
Location Verification: Fixes and additions to test cases

### DIFF
--- a/tests/test-api-location-verification.html
+++ b/tests/test-api-location-verification.html
@@ -256,6 +256,21 @@
                     expect(error.response.status).to.equal(400);
                 }
             });
+
+            it("Invalid accuracy parameter should return 400", async function() {
+                try {
+                    let response = await axios.post(`${baseURL}/verifications`, {
+                        device: device,
+                        area: area3
+                    }, {
+                        headers: {
+                            Authorization: `Bearer ${token}`
+                        }
+                    });
+                } catch (error) {
+                    expect(error.response.status).to.be.equal(400);
+                }
+            });
         });
     });
 

--- a/tests/test-api-location-verification.html
+++ b/tests/test-api-location-verification.html
@@ -211,7 +211,7 @@
                     }
                 });
                 expect(response.status).to.equal(200);
-                expect(response.data.verificationResult).to.be.a('string');
+                expect(response.data.verificationResult).to.be.a('boolean');
             });
 
             it("Invalid device should return 404", async function () {

--- a/tests/test-api-location-verification.html
+++ b/tests/test-api-location-verification.html
@@ -66,6 +66,9 @@
             publicPort: 59765
         }
     };
+
+    const maxAge = 100;
+
     const area = {
         type: 'Circle',
         location: {
@@ -76,7 +79,7 @@
     };
 
     const expectedResponse = {
-      verificationResult: 'TRUE',
+        verificationResult: 'TRUE',
     };
 
     const device2 = {
@@ -84,23 +87,23 @@
     };
 
     const expectedResponse2 = {
-      verificationResult: 'PARTIAL',
-      matchRate: 74,
+        verificationResult: 'PARTIAL',
+        matchRate: 74,
     };
 
     const area3 = {
-      type: 'Circle',
-      location: {
-        latitude: 50.735851,
-        longitude: 7.10066
-      },
-      accuracy: -10 // Invalid accuracy
+        type: 'Circle',
+        location: {
+            latitude: 50.735851,
+            longitude: 7.10066
+        },
+        accuracy: -10 // Invalid accuracy
     };
 
     const expectedResponse3 = {
-      status: 400,
-      code: 'INVALID_ARGUMENT',
-      message: 'Invalid input',
+        status: 400,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid input',
     };
 
 
@@ -214,6 +217,24 @@
                 expect(response.data.verificationResult).to.be.a('boolean');
             });
 
+            it("Successful verification with maxAge should return 200 OR 422", async function () {
+                try {
+                    let response = await axios.post(`${baseURL}/verifications`, {
+                        device: device,
+                        area: area,
+                        maxAge: maxAge
+                    }, {
+                        headers: {
+                            Authorization: `Bearer ${token}`
+                        }
+                    });
+                    expect(response.status).to.equal(200);
+                    expect(response.data.verificationResult).to.be.a('boolean');
+                } catch (error) {
+                    expect(error.response.status).to.equal(422);
+                }
+            });
+
             it("Invalid device should return 404", async function () {
                 try {
                     let response = await axios.post(`${baseURL}/verifications`, {
@@ -257,7 +278,7 @@
                 }
             });
 
-            it("Invalid accuracy parameter should return 400", async function() {
+            it("Invalid accuracy parameter should return 400", async function () {
                 try {
                     let response = await axios.post(`${baseURL}/verifications`, {
                         device: device,

--- a/tests/test-api-location-verification.html
+++ b/tests/test-api-location-verification.html
@@ -278,19 +278,18 @@
                 }
             });
 
-            it("Invalid accuracy parameter should return 400", async function () {
-                try {
-                    let response = await axios.post(`${baseURL}/verifications`, {
-                        device: device,
-                        area: area3
-                    }, {
-                        headers: {
-                            Authorization: `Bearer ${token}`
-                        }
-                    });
-                } catch (error) {
-                    expect(error.response.status).to.be.equal(400);
-                }
+            it("Invalid accuracy parameter should return 200 with false", async function () {
+                let response = await axios.post(`${baseURL}/verifications`, {
+                    device: device,
+                    area: area3
+                }, {
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    }
+                });
+                expect(response.status).to.equal(200);
+                expect(response.data.verificationResult).to.be.a('boolean');
+                expect(response.data.verificationResult).equal(false);
             });
         });
     });


### PR DESCRIPTION
Team 8: Packet Droppers

### Description
Fixed existing test case for `Successful verification should return 200`
- Expected `verificationResult` type should be a `boolean`

Added 2 additional test cases
- Invalid accuracy parameter as a negative integer should return `400`
- Optional `maxAge` parameter should return `200`, or `422` in the case the system is unable to provide a response given the valid parameter (as per API specifications)

Misc changes
- Fixed indentations