### PR TITLE
TYPO FIX: "center" key should be "location"

### DIFF
--- a/API/location-verification.yaml
+++ b/API/location-verification.yaml
@@ -123,7 +123,7 @@ paths:
                     phoneNumber: "+123456789"
                   area:
                     areaType: CIRCLE
-                    center:
+                    location:
                       latitude: 50.735851
                       longitude: 7.10066
                     radius: 50000
@@ -138,7 +138,7 @@ paths:
                       publicPort: 1234
                   area:
                     areaType: CIRCLE
-                    center:
+                    location:
                       latitude: 50.735851
                       longitude: 7.10066
                     radius: 50000
@@ -148,7 +148,7 @@ paths:
                 value:
                   area:
                     areaType: CIRCLE
-                    center:
+                    location:
                       latitude: 50.735851
                       longitude: 7.10066
                     radius: 50000
@@ -265,7 +265,7 @@ components:
             - radius
       example:
         areaType: CIRCLE
-        center:
+        location:
           latitude: 50.735851
           longitude: 7.10066
         radius: 50000

--- a/API/location-verification.yaml
+++ b/API/location-verification.yaml
@@ -126,7 +126,7 @@ paths:
                     location:
                       latitude: 50.735851
                       longitude: 7.10066
-                    radius: 50000
+                    accuracy: 50000
                   maxAge: 120
               INPUT_IP_ADDRESS_V4_CIRCLE:
                 summary: IPv4 address, circle, without maxAge
@@ -141,7 +141,7 @@ paths:
                     location:
                       latitude: 50.735851
                       longitude: 7.10066
-                    radius: 50000
+                    accuracy: 50000
               INPUT_NO_DEVICE:
                 summary: Device not provided
                 description: The device has to be deducted from token
@@ -151,7 +151,7 @@ paths:
                     location:
                       latitude: 50.735851
                       longitude: 7.10066
-                    radius: 50000
+                    accuracy: 50000
                   maxAge: 120
       responses:
         "200":


### PR DESCRIPTION
If you try to make the API call with "center" it will return an internal server error. Switching "center" to "location" makes the call work as expected.

The "radius" key was also a typo so I switched it to "accuracy".